### PR TITLE
Make password entry in settings non-required

### DIFF
--- a/data/settings.html
+++ b/data/settings.html
@@ -29,7 +29,7 @@
 		<fieldset>
 			<legend><h4 style="padding:0px 4px;">Wifi</h4></legend>
 			<div><input class="w3-input" type="text" id="SSID" name="SSID" maxlength="31" required><label class="w3-label w3-validate">SSID</label></div>
-			<div><input class="w3-input" type="password" id="PSK" name="PSK" maxlength="63" required><label class="w3-label w3-validate">Password</label></div>
+			<div><input class="w3-input" type="password" id="PSK" name="PSK" maxlength="63"><label class="w3-label w3-validate">Password</label></div>
 		</fieldset>
 		<br>
 		<fieldset>


### PR DESCRIPTION
I wanted to connect the ESP to an AP that has no password, but the settings page did not permit an empty password field. This patch permits an empty password.
